### PR TITLE
左右の読み捨て / 選択パーサを実装、電卓未実装

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -22,6 +22,11 @@ struct Ast {
     expr: Expr
 }
 
+pub fn exec(input: &str) -> Ast {
+    // どのようにして parser を呼び出して、AST を構築すべきか？
+    // パーサの引数に渡して行って破壊的変更していく？
+}
+
 
 // any_char, plus とかの parser を共通の型で縛りたい
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,74 +1,77 @@
-#[allow(dead_code)]
-struct Input {
-    pos: u32,
-    text: String,
+struct Nat {
+    value: i64
 }
 
-#[allow(dead_code)]
-struct Ast {}
+enum Factor {
+    Nat(Nat),
+    Paren(Box<Expr>)
+}
 
-#[allow(dead_code)]
-struct Parser {}
+
+enum Term {
+    Nat(Nat),
+    Factor(Factor)
+}
+
+enum Expr {
+    Plus(Box<Expr>, Box<Expr>),
+    Term(Term)
+}
+
+struct Ast {
+    expr: Expr
+}
+
 
 // any_char, plus とかの parser を共通の型で縛りたい
 
-#[allow(dead_code)]
-fn any_char(input: &str) -> Option<(char, &str)> {
+pub fn any_char(input: &str) -> Option<(char, &str)> {
     input.chars().next().map(|first| (first, &input[1..]))
 }
 
 // 条件を渡すとパーサーを作ってくれる
-#[allow(dead_code)]
-fn sat(pred: impl Fn(char) -> bool) -> impl FnOnce(&str) -> Option<(char, &str)> {
+pub fn sat(pred: impl Fn(char) -> bool) -> impl FnOnce(&str) -> Option<(char, &str)> {
     move |input| -> Option<(char, &str)> {
         any_char(input).and_then(|(parsed, rest)| pred(parsed).then(|| (parsed, rest)))
     }
 }
 
-fn prefix(pr: char) -> impl FnOnce(&str) -> Option<(char, &str)> {
+pub fn prefix(pr: char) -> impl FnOnce(&str) -> Option<(char, &str)> {
     let pred = move |input: char| -> bool { pr == input };
     sat(pred)
 }
 
-fn is_target_char(tc: char) {}
 
-#[allow(dead_code)]
-fn is_digit(input: char) -> bool {
+pub fn is_digit(input: char) -> bool {
     matches!(input, '0'..='9')
 }
 
-#[allow(dead_code)]
-fn is_plus(input: char) -> bool {
+pub fn is_plus(input: char) -> bool {
     matches!(input, '+')
 }
 
-#[allow(dead_code)]
-fn is_factor(input: char) -> bool {
+pub fn is_factor(input: char) -> bool {
     matches!(input, '*')
 }
 
-#[allow(dead_code)]
-fn plus(input: &str) -> Option<(char, &str)> {
+pub fn plus(input: &str) -> Option<(char, &str)> {
     let plus = sat(is_plus);
     plus(input)
 }
 
-#[allow(dead_code)]
-fn factor(input: &str) -> Option<(char, &str)> {
+pub fn factor(input: &str) -> Option<(char, &str)> {
     let plus = sat(is_factor);
     plus(input)
 }
 
-#[allow(dead_code)]
-fn digit(input: &str) -> Option<(char, &str)> {
+pub fn digit(input: &str) -> Option<(char, &str)> {
     let plus = sat(is_digit);
     plus(input)
 }
 
 // parse many digit "3333a"
 // ((many digit) "3333a") -> Some(("3333","a"))
-#[allow(dead_code)]
-fn many(
+pub fn many(
     parser: impl Fn(&str) -> Option<(char, &str)>,
 ) -> impl FnOnce(&str) -> Option<(String, &str)> {
     move |input| {
@@ -86,7 +89,7 @@ fn many(
 // 左でパースした後に、その結果を入力に右でパーサーした結果を出力するパーサー
 // let get_second = naive_left(any_char, any_char)
 // get_second("abcd") // [b, cd]
-fn discard_left(
+pub fn discard_left(
     pA: impl Fn(&str) -> Option<(char, &str)>,
     pB: impl Fn(&str) -> Option<(char, &str)>,
 ) -> impl Fn(&str) -> Option<(char, &str)> {
@@ -97,7 +100,7 @@ fn discard_left(
 }
 
 // 右でパースした後に、その結果を入力に右でパーサーした結果を出力するパーサー
-fn naive_discard_right(
+pub fn naive_discard_right(
     pA: impl Fn(&str) -> Option<(char, &str)>,
     pB: impl Fn(&str) -> Option<(char, &str)>,
 ) -> impl Fn(&str) -> Option<(char, &str)> {
@@ -114,7 +117,7 @@ fn naive_discard_right(
     }
 }
 
-fn alternative(
+pub fn alternative(
     pA: impl Fn(&str) -> Option<(char, &str)>,
     pB: impl Fn(&str) -> Option<(char, &str)>,
 ) -> impl Fn(&str) -> Option<(char, &str)> {
@@ -126,9 +129,6 @@ fn alternative(
         }
     }
 }
-
-// exec(1 + 3)
-fn exec(expr: &str) {}
 
 #[cfg(test)]
 mod tests {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -95,23 +95,18 @@ fn naive_discard_left(pA: impl Fn(&str) -> Option<(char, &str)>, pB: impl Fn(&st
 // 右でパースした後に、その結果を入力に右でパーサーした結果を出力するパーサー
 fn naive_discard_right(pA: impl Fn(&str) -> Option<(char, &str)>, pB: impl Fn(&str) -> Option<(char, &str)>)-> impl Fn(&str) -> Option<(char, &str)>{
     move |input| {
-        let left_parsed = pA(input);
-        match left_parsed {
-            Some(s) => {
-                let parsed = pB(s.1);
-                match parsed {
+        let left_parsed = pA(input).and_then(|(parsed, rest)|{
+            let parsed2 = pB(rest);
+            match parsed2 {
                     Some(s2) => {
-                        Some((s.0, s2.1))
+                        Some((parsed, s2.1))
                     }
                     None => {
                         None
                     }
                 }
-            },
-            None => {
-                None
-            }
-        }
+        });
+        left_parsed
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -85,15 +85,10 @@ fn many(
 // ナイーブに実装。あとで monadic に書き換える
 fn naive_discard_left(pA: impl Fn(&str) -> Option<(char, &str)>, pB: impl Fn(&str) -> Option<(char, &str)>)-> impl Fn(&str) -> Option<(char, &str)>{
     move |input| {
-        let left_parsed = pA(input);
-        match left_parsed {
-            Some(s) => {
-                pB(s.1)
-            },
-            None => {
-                None
-            }
-        }
+        let left_parsed = pA(input).and_then(|(parsed, rest)|{
+            pB(rest)
+        });
+        left_parsed
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -82,8 +82,7 @@ fn many(
 // 左でパースした後に、その結果を入力に右でパーサーした結果を出力するパーサー
 // let get_second = naive_left(any_char, any_char)
 // get_second("abcd") // [b, cd]
-// ナイーブに実装。あとで monadic に書き換える
-fn naive_discard_left(pA: impl Fn(&str) -> Option<(char, &str)>, pB: impl Fn(&str) -> Option<(char, &str)>)-> impl Fn(&str) -> Option<(char, &str)>{
+fn discard_left(pA: impl Fn(&str) -> Option<(char, &str)>, pB: impl Fn(&str) -> Option<(char, &str)>)-> impl Fn(&str) -> Option<(char, &str)>{
     move |input| {
         let left_parsed = pA(input).and_then(|(parsed, rest)|{
             pB(rest)
@@ -97,6 +96,7 @@ fn naive_discard_right(pA: impl Fn(&str) -> Option<(char, &str)>, pB: impl Fn(&s
     move |input| {
         let left_parsed = pA(input).and_then(|(parsed, rest)|{
             let parsed2 = pB(rest);
+            // Q: ここも and_then で書きたいが、parsed を使いたいのでかけない
             match parsed2 {
                     Some(s2) => {
                         Some((parsed, s2.1))
@@ -159,7 +159,7 @@ mod tests {
 
     #[test]
     fn naive_discard_left_test(){
-        let left_parser = naive_discard_left(any_char, any_char);
+        let left_parser = discard_left(any_char, any_char);
         let actual = left_parser("abcde");
         assert_eq!(actual, Some(('b', "cde")));
     }
@@ -175,7 +175,7 @@ mod tests {
     // let get_middle =right_parser(left_parser(get_char, get_char), get_char)
     #[test]
     fn middle(){
-        let middle_parser = naive_discard_left(any_char, naive_discard_right(any_char, any_char));
+        let middle_parser = discard_left(any_char, naive_discard_right(any_char, any_char));
         let actual = middle_parser("abc");
         assert_eq!(actual, Some(('b', "")));
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -39,7 +39,7 @@ fn is_target_char(tc: char){
 }
 
 #[allow(dead_code)]
-fn is_num(input: char) -> bool {
+fn is_digit(input: char) -> bool {
     matches!(input, '0'..='9')
 }
 
@@ -66,8 +66,8 @@ fn factor(input: &str) -> Option<(char, &str)> {
 }
 
 #[allow(dead_code)]
-fn num(input: &str) -> Option<(char, &str)> {
-    let plus = sat(is_num);
+fn digit(input: &str) -> Option<(char, &str)> {
+    let plus = sat(is_digit);
     plus(input)
 }
 
@@ -182,7 +182,7 @@ mod tests {
 
     #[test]
     fn many_parse() {
-        let many_parser = many(num);
+        let many_parser = many(digit);
         let actual = many_parser("123a");
         assert_eq!(actual, Some(("123".to_string(), "a")));
     }
@@ -215,5 +215,14 @@ mod tests {
         let start_paren_parser = prefix('(');
         let actual = start_paren_parser("(1+2)*3");
         assert_eq!(actual, Some(('(', "1+2)*3")));
+    }
+
+    #[test]
+    fn alternative_test(){
+        let plus_or_digit_parser = alternative(digit, plus);
+        let actual = plus_or_digit_parser("+2");
+        assert_eq!(actual, Some(('+', "2")));
+        let actual = plus_or_digit_parser("1+2");
+        assert_eq!(actual, Some(('1', "+2")));
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,3 @@
-
-
-
-   
 #[allow(dead_code)]
 struct Input {
     pos: u32,
@@ -87,7 +83,7 @@ fn many(
 // let get_second = naive_left(any_char, any_char)
 // get_second("abcd") // [b, cd]
 // ナイーブに実装。あとで monadic に書き換える
-fn naive_left(pA: impl Fn(&str) -> Option<(char, &str)>, pB: impl Fn(&str) -> Option<(char, &str)>)-> impl Fn(&str) -> Option<(char, &str)>{
+fn naive_discard_left(pA: impl Fn(&str) -> Option<(char, &str)>, pB: impl Fn(&str) -> Option<(char, &str)>)-> impl Fn(&str) -> Option<(char, &str)>{
     move |input| {
         let left_parsed = pA(input);
         match left_parsed {
@@ -102,7 +98,7 @@ fn naive_left(pA: impl Fn(&str) -> Option<(char, &str)>, pB: impl Fn(&str) -> Op
 }
 
 // 右でパースした後に、その結果を入力に右でパーサーした結果を出力するパーサー
-fn naive_right(pA: impl Fn(&str) -> Option<(char, &str)>, pB: impl Fn(&str) -> Option<(char, &str)>)-> impl Fn(&str) -> Option<(char, &str)>{
+fn naive_discard_right(pA: impl Fn(&str) -> Option<(char, &str)>, pB: impl Fn(&str) -> Option<(char, &str)>)-> impl Fn(&str) -> Option<(char, &str)>{
     move |input| {
         let left_parsed = pA(input);
         match left_parsed {
@@ -172,15 +168,15 @@ mod tests {
     }
 
     #[test]
-    fn naive_left_parse(){
-        let left_parser = naive_left(any_char, any_char);
+    fn naive_discard_left_test(){
+        let left_parser = naive_discard_left(any_char, any_char);
         let actual = left_parser("abcde");
         assert_eq!(actual, Some(('b', "cde")));
     }
 
     #[test]
-    fn naive_right_parse(){
-        let right_parser = naive_right(any_char, any_char);
+    fn naive_discard_right_test(){
+        let right_parser = naive_discard_right(any_char, any_char);
         let actual = right_parser("abcde");
         assert_eq!(actual, Some(('a', "cde")));
     }
@@ -189,7 +185,7 @@ mod tests {
     // let get_middle =right_parser(left_parser(get_char, get_char), get_char)
     #[test]
     fn middle(){
-        let middle_parser = naive_left(any_char, naive_right(any_char, any_char));
+        let middle_parser = naive_discard_left(any_char, naive_discard_right(any_char, any_char));
         let actual = middle_parser("abc");
         assert_eq!(actual, Some(('b', "")));
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -27,6 +27,17 @@ fn sat(
     }
 }
 
+fn prefix(pr: char) -> impl FnOnce(&str) -> Option<(char, &str)>{
+    let pred = move |input: char|->bool{
+        pr == input
+    };
+    sat(pred)
+}
+
+fn is_target_char(tc: char){
+
+}
+
 #[allow(dead_code)]
 fn is_num(input: char) -> bool {
     matches!(input, '0'..='9')
@@ -110,6 +121,25 @@ fn naive_discard_right(pA: impl Fn(&str) -> Option<(char, &str)>, pB: impl Fn(&s
     }
 }
 
+fn alternative(pA: impl Fn(&str) -> Option<(char, &str)>, pB: impl Fn(&str) -> Option<(char, &str)>) ->impl Fn(&str) -> Option<(char, &str)> {
+    move |input| {
+        let parsed = pA(input);
+        match parsed {
+            Some(p) => {
+                Some(p)
+            },
+            None => {
+                pB(input)
+            }
+        }
+    }
+}
+
+// exec(1 + 3)
+fn exec(expr: &str){
+
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -178,5 +208,12 @@ mod tests {
         let middle_parser = discard_left(any_char, naive_discard_right(any_char, any_char));
         let actual = middle_parser("abc");
         assert_eq!(actual, Some(('b', "")));
+    }
+
+    #[test]
+    fn prefix_test(){
+        let start_paren_parser = prefix('(');
+        let actual = start_paren_parser("(1+2)*3");
+        assert_eq!(actual, Some(('(', "1+2)*3")));
     }
 }


### PR DESCRIPTION
- 電卓を実装するにあたって、haskell みたいに BNF そのものの宣言にパーサー混ぜこむみたいな実装ができず、一度 AST を構築して printer を経由して計算結果を出力させる方針にしたが、ASTの構築方法が分からない。具体的にはパーサーからどのようにしてAST構造体に書き込めばいいかが分からない
- そもそも構造体でASTを表現する方法がよく分からなかった。BNFを構造体で表現してみたが方針としてあっているか見て欲しい。`expr * expr | term` みたいなものは Enum で表現すべき？
- parse_while を実装したい。例えば `prefix "[" *> parse_while (fun x -> x != ']') <* any_char` のようなことを実現したい。挑戦してみてできなかったのでペアプロしてほしい
- `prefix "[" *> parse_while (fun x -> x != ']') <* any_char` を中置記法を使わずに書くならどのような結合順を前提として作るべき？
- Rust では `*>`, `<*` を中置記法として演算子定義ができないが、この関数はどのような命名がいいか？
- `<*` の実装で、一回目の Option 展開時の値を使わないといけなくて、and_then を使えなかった。ここを monadic に書き換えるならどうすればいいか。同様の疑問は alternative の実装にも当てはまる。

## TODO

- [ ] monadic な連接パーサー作る